### PR TITLE
Fix hardcoded base path in validate_readmes.py script to work dynamically

### DIFF
--- a/scripts/validate_readmes.py
+++ b/scripts/validate_readmes.py
@@ -91,7 +91,7 @@ def validate_readme_format(readme_path, tool_name, tool_path):
 
 def main():
     """Main function to validate all tool READMEs."""
-    base_path = Path('/Users/nirg/repositories/awesome-devops')
+    base_path = Path(__file__).resolve().parent.parent
     tools_path = base_path / 'tools'
 
     if not tools_path.exists():


### PR DESCRIPTION
# Pull Request Template

## Description

Updated hardcoded base path in validate_readmes.py script to work dynamically (was local to Nir's)

when running python scripts/validate_readmes.py, the output is:
```
$ python scripts/validate_readmes.py
> "Tools directory not found"
```

this is because "base_path" in the script is pointing to '/Users/nirg/repositories/awesome-devops'.
the line has been changed to 'base_path = Path(__file__).resolve().parents[1]'.


## Type of Change

- [ ] New tool addition
- [ ] Tool update/removal
- [ ] Documentation update
- [X] Other (script update - validate_readme.py)

## Checklist

- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] The tool is added to the correct category in `tools/`
- [ ] A README.md has been created for the tool using `scripts/create_readmes.sh`
- [ ] Logos have been added to `logos/` and mapped in `logos/mapping.csv` (if applicable)
- [ ] All links are valid and point to official sources
- [ ] The commit message follows the format: "Add [Tool Name] to Awesome DevOps"
- [ ] No unrelated changes are included
- [ ] The tool is actively maintained and relevant to DevOps
- [ ] No duplicate tools exist

## Additional Information

this is a technical update, not content update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved path resolution in the validation tooling to use dynamic script location instead of hardcoded paths, enhancing portability and robustness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->