### PR TITLE
feat: add SandBase Harness MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,6 +636,7 @@ Tool | Description
 | **[mindsdb](tools/MCP/mindsdb/)** | AI-powered database management and analytics. |
 | **[playwright-mcp](tools/MCP/playwright-mcp/)** | Browser automation and web scraping with Playwright. |
 | **[serena](tools/MCP/serena/)** | AI-powered development assistant. |
+| **[SandBase-Harness](tools/MCP/SandBase-Harness/)** | Local-first agent runtime and MCP bridge for governed DevOps automation. |
 
 ## Networking Tools
 Tool | Description

--- a/tools/MCP/README.md
+++ b/tools/MCP/README.md
@@ -18,6 +18,7 @@ The Model Context Protocol (MCP) is a standard for connecting AI assistants to e
 - [mindsdb](mindsdb/) - AI-powered database management and analytics
 - [playwright-mcp](playwright-mcp/) - Browser automation and web scraping with Playwright
 - [serena](serena/) - AI-powered development assistant
+- [SandBase-Harness](SandBase-Harness/) - Local-first agent runtime and MCP bridge for governed DevOps automation
 
 ## Resources
 

--- a/tools/MCP/SandBase-Harness/README.md
+++ b/tools/MCP/SandBase-Harness/README.md
@@ -1,0 +1,25 @@
+# SandBase-Harness
+
+![SandBase-Harness Logo](../logos/sandbase-harness.svg)
+
+## Overview
+
+SandBase Harness is an open-source, local-first agent runtime and MCP bridge for governed DevOps automation and tool workflows.
+
+## Key Features
+
+- Persistent sessions and resumable runtime state
+- Explicit approvals, credential scoping, audit, and replay
+- Docker, Kubernetes, and worker execution backends
+- MCP tools for auditable DevOps-oriented agent workflows
+
+## Getting Started
+
+Install the CLI or run the public MCP bridge with Docker. Follow the [installation guide](https://github.com/sandbaseai/sandbase-harness/blob/main/docs/installation.md) for setup and deployment options.
+
+## Resources
+
+- [GitHub Repository](https://github.com/sandbaseai/sandbase-harness)
+- [Latest Release](https://github.com/sandbaseai/sandbase-harness/releases/latest)
+- [Installation Guide](https://github.com/sandbaseai/sandbase-harness/blob/main/docs/installation.md)
+- [Security Boundary](https://github.com/sandbaseai/sandbase-harness/blob/main/docs/security.md)

--- a/tools/MCP/SandBase-Harness/README.md
+++ b/tools/MCP/SandBase-Harness/README.md
@@ -22,4 +22,4 @@ Install the CLI or run the public MCP bridge with Docker. Follow the [installati
 - [GitHub Repository](https://github.com/sandbaseai/sandbase-harness)
 - [Latest Release](https://github.com/sandbaseai/sandbase-harness/releases/latest)
 - [Installation Guide](https://github.com/sandbaseai/sandbase-harness/blob/main/docs/installation.md)
-- [Security Boundary](https://github.com/sandbaseai/sandbase-harness/blob/main/docs/security.md)
+- [Sandbox Backends and Security Boundary](https://github.com/sandbaseai/sandbase-harness/blob/main/docs/usage.md#sandbox-backends)

--- a/tools/MCP/logos/sandbase-harness.svg
+++ b/tools/MCP/logos/sandbase-harness.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">SandBase Harness</title>
+  <desc id="desc">SandBase Harness logo</desc>
+  <rect width="64" height="64" rx="14" fill="#111827"/>
+  <path d="M18 20h28v8H26v4h14c4.4 0 8 3.6 8 8s-3.6 8-8 8H18v-8h20v-4H26c-4.4 0-8-3.6-8-8s3.6-8 8-8Z" fill="#38bdf8"/>
+</svg>


### PR DESCRIPTION
## Summary

- add SandBase Harness to the MCP tools section
- document its local-first runtime, governed execution, and DevOps workflow focus
- include installation, release, and security resources

## Validation

- `git diff --check`
- `python3 scripts/validate_readmes.py` (the new `MCP/SandBase-Harness` entry passes; the repository has pre-existing validation failures in unrelated entries)

SandBase Harness is an open-source MCP bridge and agent runtime: https://github.com/sandbaseai/sandbase-harness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SandBase Harness to the MCP tools catalog.
  * Added introductory documentation describing its local-first agent runtime and MCP bridge capabilities.
  * Documented persistent sessions, approval controls, credential scoping, auditing, execution backends, and MCP workflows.
  * Added getting-started instructions and links to installation, release, repository, and security resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->